### PR TITLE
[CBP-42405] chore: Update latest image version in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
   steps:
     - id: invoke-tosca-actions
       name: invoke-tosca-actions
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/tosca-actions:main-f7055ceffd7226e972714178b912300e9d123354
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/tosca-actions:main-a841b2fb2c90c965537da6d2a141ade882b8c06e
       shell: sh
       run: |
         set -x


### PR DESCRIPTION
Update docker image tag to latest version from `action_artifacts.json`.